### PR TITLE
Encode Google OAuth token request

### DIFF
--- a/api/oauth/exchange.js
+++ b/api/oauth/exchange.js
@@ -26,13 +26,23 @@ export default async function handler(req, res) {
 
         if (provider === 'google') {
             // Échanger le code Google contre des tokens
-            const tokenResponse = await axios.post('https://oauth2.googleapis.com/token', {
+            const tokenPayload = new URLSearchParams({
                 client_id: process.env.GOOGLE_CLIENT_ID,
                 client_secret: process.env.GOOGLE_CLIENT_SECRET,
                 code: code,
                 grant_type: 'authorization_code',
                 redirect_uri: redirectUri,
             });
+
+            const tokenResponse = await axios.post(
+                'https://oauth2.googleapis.com/token',
+                tokenPayload.toString(),
+                {
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                },
+            );
 
             const { access_token, refresh_token, expires_in } = tokenResponse.data;
 


### PR DESCRIPTION
## Summary
- build the Google OAuth token payload using URLSearchParams so it is form-encoded
- submit the encoded payload to Google with the proper application/x-www-form-urlencoded header

## Testing
- `npm run lint` *(fails: existing eslint no-undef errors for process in multiple API files and unused var in src/App.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d12330c4f883308674f3b34f099f7d