### PR TITLE
refactor: share oauth token store

### DIFF
--- a/api/_lib/tokenStore.js
+++ b/api/_lib/tokenStore.js
@@ -1,0 +1,4 @@
+// Shared in-memory token store used by all OAuth-related endpoints.
+const userTokens = new Map();
+
+export default userTokens;

--- a/api/n8n/trigger.js
+++ b/api/n8n/trigger.js
@@ -1,8 +1,7 @@
 // api/n8n/trigger.js
 import axios from 'axios';
 
-// Store temporaire (même que dans exchange.js)
-const userTokens = new Map();
+import userTokens from '../_lib/tokenStore.js';
 
 export default async function handler(req, res) {
     // CORS

--- a/api/oauth/exchange.js
+++ b/api/oauth/exchange.js
@@ -1,8 +1,7 @@
 // api/oauth/exchange.js
 import axios from 'axios';
 
-// Store temporaire pour les tokens (en attendant Supabase)
-const userTokens = new Map();
+import userTokens from '../_lib/tokenStore.js';
 
 export default async function handler(req, res) {
     // CORS

--- a/api/oauth/revoke.js
+++ b/api/oauth/revoke.js
@@ -1,8 +1,7 @@
 // api/oauth/revoke.js
 import axios from 'axios';
 
-// Store temporaire (même que dans exchange.js)
-const userTokens = new Map();
+import userTokens from '../_lib/tokenStore.js';
 
 export default async function handler(req, res) {
     // CORS

--- a/api/oauth/status.js
+++ b/api/oauth/status.js
@@ -1,7 +1,6 @@
 // api/oauth/status.js
 
-// Store temporaire (même que dans exchange.js - en attendant Supabase)
-const userTokens = new Map();
+import userTokens from '../_lib/tokenStore.js';
 
 export default async function handler(req, res) {
     // CORS


### PR DESCRIPTION
## Summary
- add a shared in-memory token store under api/_lib
- update OAuth exchange/status/revoke and n8n trigger endpoints to use the common store

## Testing
- npm run lint *(fails: existing lint errors for process global and motion import)*

------
https://chatgpt.com/codex/tasks/task_e_68d1232fc8cc8330ae92176490ff845a